### PR TITLE
Color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To install on the Turris Omnia:
 
 ```shell
 opkg update
-opkg install git
+opkg install git luabitop
 git clone git://github.com/ddrown/omnia-led-colors.git
 cd omnia-led-colors
 ./install
@@ -12,6 +12,8 @@ cd omnia-led-colors
 ```
 
 To update an existing install:
+
+_Ensure that luabitop is installed_
 
 ```shell
 cd omnia-led-colors

--- a/install
+++ b/install
@@ -5,7 +5,7 @@ chmod 755 /usr/sbin/omnia-led-colors
 cp omnia-led-colors.init.d /etc/init.d/omnia-led-colors
 chmod 755 /etc/init.d/omnia-led-colors
 
-[ -f /etc/config/omnia-led-colors ] || cp omnia-led-colors.config /etc/config/omnia-led-colors
+[ /etc/config/omnia-led-colors -nt omnia-led-colors.config ] || cp omnia-led-colors.config /etc/config/omnia-led-colors
 
 /etc/init.d/omnia-led-colors enable
 /etc/init.d/omnia-led-colors start

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -166,7 +166,7 @@ function bandwidth_led(ledname,arguments)
   local interface, direction, limit = arguments.interface, arguments.direction, arguments.limit
 
   --colors
-  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
+  local nominal, critical = tonumber(arguments.nominal or '0x00FF00'), tonumber(arguments.critical or '0xFF0000')
 
   local wan_data = data.wan[interface]
 
@@ -198,7 +198,7 @@ function ath9k_led(ledname,arguments)
   local interface = arguments.interface
 
   --colors
-  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
+  local nominal, critical = tonumber(arguments.nominal or '0x00FF00'), tonumber(arguments.critical or '0xFF0000')
 
   local pct = gather_ath9k(interface)
 
@@ -216,7 +216,7 @@ function ath10k_led(ledname,arguments)
   local phy = arguments.phy
 
   -- colors
-  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
+  local nominal, critical = tonumber(arguments.nominal or '0x00FF00'), tonumber(arguments.critical or '0xFF0000')
 
   local pct = gather_ath10k(phy)
 

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -3,6 +3,7 @@
 -- settings are now in /etc/config/omnia-led-colors
 
 local uci = require "luci.model.uci".cursor()
+require "bit"
 require "nixio"
 
 local data = {wan={}, ath9k={}, ath10k={}}
@@ -237,13 +238,13 @@ function shift_color(nominal, critical, pct)
 
   -- bitmagic our way to individual colors
   -- remember: 0xRRGGBB
-  n_red   = bit32.arshift(bit32.band(nominal, tonumber('0xFF0000')), 16)
-  n_green = bit32.arshift(bit32.band(nominal, tonumber('0x00FF00')), 8)
-  n_blue  = bit32.band(nominal, tonumber('0x0000FF'))
+  n_red   = bit.arshift(bit.band(nominal, tonumber('0xFF0000')), 16)
+  n_green = bit.arshift(bit.band(nominal, tonumber('0x00FF00')), 8)
+  n_blue  = bit.band(nominal, tonumber('0x0000FF'))
 
-  c_red   = bit32.arshift(bit32.band(critical, tonumber('0xFF0000')), 16)
-  c_green = bit32.arshift(bit32.band(critical, tonumber('0x00FF00')), 8)
-  c_blue  = bit32.band(critical, tonumber('0x0000FF'))
+  c_red   = bit.arshift(bit.band(critical, tonumber('0xFF0000')), 16)
+  c_green = bit.arshift(bit.band(critical, tonumber('0x00FF00')), 8)
+  c_blue  = bit.band(critical, tonumber('0x0000FF'))
 
   -- actual color is a range between critical and nominal based on the load
   a_red   = math.floor(c_red + ((n_red - c_red) * (1 - pct)))

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -250,11 +250,16 @@ function shift_color(nominal, critical, pct)
   c_blue  = bit.band(critical, tonumber('0x0000FF'))
 
   -- actual color is a range between critical and nominal based on the load
-  a_red   = math.floor(c_red + ((n_red - c_red) * (1 - pct)))
-  a_green = math.floor(c_green + ((n_green - c_green) * (1 - pct)))
-  a_blue  = math.floor(c_blue + ((n_blue - c_blue) * (1 - pct)))
+  a_red   = interpolate(n_red, c_red, pct)
+  a_green = interpolate(n_green, c_green, pct)
+  a_blue  = interpolate(n_blue, c_blue, pct)
 
   return {a_red, a_green, a_blue}
+end
+
+function interpolate(nominal, critical, pct)
+  pct = math.min(pct, 1)
+  return math.floor((critical * pct) + (nominal * (1 - pct)))
 end
 
 function setled(led)

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -165,6 +165,9 @@ end
 function bandwidth_led(ledname,arguments)
   local interface, direction, limit = arguments.interface, arguments.direction, arguments.limit
 
+  --colors
+  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
+
   local wan_data = data.wan[interface]
 
   if wan_data == nil then
@@ -184,17 +187,18 @@ function bandwidth_led(ledname,arguments)
     pct = wan_data.bps_out / limit
   end
 
-  -- 0% = green, 50% = yellow, 100% = red
-  local green = math.floor(math.max(1-pct,0)*255)
-  local red = math.min(math.floor(pct*255),255)
-
   debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." 0)")
 
-  write_led(ledname, red, green, 0)
+  local red, green, blue = shift_color(nominal, critical, pct)
+
+  write_led(ledname, red, green, blue)
 end
 
 function ath9k_led(ledname,arguments)
   local interface = arguments.interface
+
+  --colors
+  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
 
   local pct = gather_ath9k(interface)
 
@@ -203,15 +207,16 @@ function ath9k_led(ledname,arguments)
     return
   end
 
-  -- 0% = green, 50% = yellow, 100% = red
-  local green = math.floor(math.max(1-pct,0)*255)
-  local red = math.min(math.floor(pct*255),255)
+  local red, green, blue = shift_color(nominal, critical, pct)
 
-  write_led(ledname, red, green, 0)
+  write_led(ledname, red, green, blue)
 end
 
 function ath10k_led(ledname,arguments)
   local phy = arguments.phy
+
+  -- colors
+  local nominal, critical = (arguments.nominal or tonumber('0x00FF00')), (arguments.critical or tonumber('0xFF0000'))
 
   local pct = gather_ath10k(phy)
 
@@ -220,11 +225,32 @@ function ath10k_led(ledname,arguments)
     return
   end
 
-  -- 0% = green, 50% = yellow, 100% = red
-  local green = math.floor(math.max(1-pct,0)*255)
-  local red = math.min(math.floor(pct*255),255)
+  local red, green, blue = shift_color(nominal, critical, pct)
 
-  write_led(ledname, red, green, 0)
+  write_led(ledname, red, green, blue)
+end
+
+function shift_color(nominal, critical, pct)
+  local n_red, n_green, n_blue, -- nominal colors
+        c_red, c_green, c_blue, -- critical colors
+        a_red, a_green, a_blue  -- actual colors
+
+  -- bitmagic our way to individual colors
+  -- remember: 0xRRGGBB
+  n_red   = bit32.arshift(bit32.band(nominal, tonumber('0xFF0000')), 16)
+  n_green = bit32.arshift(bit32.band(nominal, tonumber('0x00FF00')), 8)
+  n_blue  = bit32.band(nominal, tonumber('0x0000FF'))
+
+  c_red   = bit32.arshift(bit32.band(critical, tonumber('0xFF0000')), 16)
+  c_green = bit32.arshift(bit32.band(critical, tonumber('0x00FF00')), 8)
+  c_blue  = bit32.band(critical, tonumber('0x0000FF'))
+
+  -- actual color is a range between critical and nominal based on the load
+  a_red   = math.floor(c_red + ((n_red - c_red) * (1 - pct)))
+  a_green = math.floor(c_green + ((n_green - c_green) * (1 - pct)))
+  a_blue  = math.floor(c_blue + ((n_blue - c_blue) * (1 - pct)))
+
+  return {a_red, a_green, a_blue}
 end
 
 function setled(led)

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -187,9 +187,9 @@ function bandwidth_led(ledname,arguments)
     pct = wan_data.bps_out / limit
   end
 
-  debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." 0)")
-
   local red, green, blue = shift_color(nominal, critical, pct)
+
+  debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." 0)")
 
   write_led(ledname, red, green, blue)
 end

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -191,7 +191,7 @@ function bandwidth_led(ledname,arguments)
   local colors = shift_color(nominal, critical, pct)
   local red, green, blue = colors[1], colors[2], colors[3]
 
-  debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." 0)")
+  debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." "..blue..")")
 
   write_led(ledname, red, green, blue)
 end

--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -188,7 +188,8 @@ function bandwidth_led(ledname,arguments)
     pct = wan_data.bps_out / limit
   end
 
-  local red, green, blue = shift_color(nominal, critical, pct)
+  local colors = shift_color(nominal, critical, pct)
+  local red, green, blue = colors[1], colors[2], colors[3]
 
   debug_print(wan_data.bps_in .."^/v".. wan_data.bps_out .. " (" .. math.floor(pct*100) .. "% "..red.." "..green .." 0)")
 
@@ -208,7 +209,8 @@ function ath9k_led(ledname,arguments)
     return
   end
 
-  local red, green, blue = shift_color(nominal, critical, pct)
+  local colors = shift_color(nominal, critical, pct)
+  local red, green, blue = colors[1], colors[2], colors[3]
 
   write_led(ledname, red, green, blue)
 end
@@ -226,7 +228,8 @@ function ath10k_led(ledname,arguments)
     return
   end
 
-  local red, green, blue = shift_color(nominal, critical, pct)
+  local colors = shift_color(nominal, critical, pct)
+  local red, green, blue = colors[1], colors[2], colors[3]
 
   write_led(ledname, red, green, blue)
 end

--- a/omnia-led-colors.config
+++ b/omnia-led-colors.config
@@ -10,17 +10,25 @@ config led wan
 	option interface 'eth1'
 	option direction 'in'
 	option limit 300000000
+        option nominal "0x00FF00"
+        option critical "0xFF0000"
 
 config led lan0
 	option colorfunction 'bandwidth'
 	option interface 'eth1'
 	option direction 'out'
 	option limit 20000000
+        option nominal "0x00FF00"
+        option critical "0xFF0000"
 
 config led pci3
 	option colorfunction 'ath9k'
 	option interface 'wlan1'
+        option nominal "0x00FF00"
+        option critical "0xFF0000"
 
 config led pci2
 	option colorfunction 'ath10k'
 	option phy 'phy0'
+        option nominal "0x00FF00"
+        option critical "0xFF0000"


### PR DESCRIPTION
Add the ability to define color dynamically.  May not work well with all color combinations, but should allow a greater range of customization.

Colors are defined in hexadecimal notation (0xFFFFFF = white, 0xFF0000 = red, etc.).

Also, made the `install` script a little better by copying the config file when it's newer than the one in /etc/config not just if it doesn't exist in /etc/config.  This makes it a little more multi-purpose.