### PR TITLE
fix: migrate to Turris OS 6.x led driver

### DIFF
--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -127,7 +127,10 @@ function gather_ath10k(ath10k_phy)
 end
 
 function write_led(ledname, r, g, b)
-  local fd = io.open("/sys/class/leds/omnia-led\:"..ledname.."/color", "w")
+  local ledalias = ledname:gsub("([a-z]+)(%d?)", "%1-%2"):gsub("-$", "")
+  local path = "/sys/class/leds/rgb:"..ledalias.."/multi_intensity"
+  debug_print("write led path: " .. path)
+  local fd = io.open(path, "w")
   fd:write(r .. " " .. g .. " " .. b)
   fd:close()
 end

--- a/omnia-led-colors.config
+++ b/omnia-led-colors.config
@@ -64,13 +64,15 @@ config led lan5
         option nominal "0x00FF00"
         option critical "0xFF0000"
 
-config led pci3
+# pci3 led
+config led wlan3
         option colorfunction 'ath9k'
         option interface 'wlan1'
         option nominal "0x00FF00"
         option critical "0xFF0000"
 
-config led pci2
+# pci2 led
+config led wlan2
         option colorfunction 'ath10k'
         option phy 'phy0'
         option nominal "0x00FF00"


### PR DESCRIPTION
This patch makes the tool compatible with the new led driver of Turris OS 6.x. WLAN PCI devices have to be renamed in existing configs.